### PR TITLE
fix: add missing -- delimiter in claude mcp add command

### DIFF
--- a/apps/svelte.dev/content/docs/mcp/20-setup/20-local-setup.md
+++ b/apps/svelte.dev/content/docs/mcp/20-setup/20-local-setup.md
@@ -16,7 +16,7 @@ npx -y @sveltejs/mcp
 Claude Code でローカル MCP バージョンを含めるには、次のコマンドを実行するだけです:
 
 ```bash
-claude mcp add -t stdio -s [scope] svelte npx -y @sveltejs/mcp
+claude mcp add -t stdio -s [scope] svelte -- npx -y @sveltejs/mcp
 ```
 
 `[scope]` には `user`、`project` または `local` を指定する必要があります。


### PR DESCRIPTION
Claude Code の `claude mcp add` コマンドの、`--` はサブコマンドへの引数と、実行するコマンドの引数を分離するためのデリミタを追加